### PR TITLE
fix: update protobuf to 5.29.6 (CVE-2026-0994)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ packaging==21.3
 pandas==1.5.2
 Pillow==9.3.0
 pipe==2.0
-protobuf==3.20.3
+protobuf==5.29.6
 pyarrow==10.0.1
 pydeck==0.8.0
 Pygments==2.13.0


### PR DESCRIPTION
## Summary

Updates `protobuf` from 3.20.3 to **5.29.6** to fix **CVE-2026-0994** (High severity).

### Vulnerability
- **Advisory:** [GHSA-7gcm-g887-7qv7](https://github.com/advisories/GHSA-7gcm-g887-7qv7)
- **Type:** JSON recursion depth bypass -> Denial of Service
- **CVSS 4.0:** 8.2 (High)
- **CWE:** CWE-674 (Uncontrolled Recursion)

### What changed
- `protobuf` 3.20.3 -> 5.29.6 in `requirements.txt`

> This is a major version bump (3.x -> 5.x). Please verify compatibility before merging.